### PR TITLE
fix error: data is not defined

### DIFF
--- a/javascript/SurfacePlot.js
+++ b/javascript/SurfacePlot.js
@@ -823,7 +823,7 @@ greg.ross.visualisation.JSSurfacePlot = function(x, y, width, height, colourGrad
         lastMousePos.y = scale / greg.ross.visualisation.JSSurfacePlot.SCALE_FACTOR;
         
         closestPointToMouse = null;
-        self.render(data);
+        self.render();
     }
     
     init();


### PR DESCRIPTION
The full error trace is:

```
SurfacePlot.js:826  Uncaught ReferenceError: data is not defined
    at calculateScale (SurfacePlot.js:826:21)
    at HTMLCanvasElement.mouseIsMoving (SurfacePlot.js:686:17)
```